### PR TITLE
Allow timeout and run period to be specified as floating point numbers; Match job full name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/queuecleanup/QueueCleanup.java
+++ b/src/main/java/org/jenkinsci/plugins/queuecleanup/QueueCleanup.java
@@ -64,7 +64,7 @@ public class QueueCleanup extends PeriodicWork implements Describable<QueueClean
         try {
              period = Float.valueOf(System.getProperty(PERIOD_KEY, period.toString()));
         } catch(NumberFormatException e) {
-             LOGGER.warning(String.format("Cannot convert string %s to integer, using dafault %d", System.getProperty(PERIOD_KEY), period));
+             LOGGER.warning(String.format("Cannot convert string %s to integer, using dafault %f", System.getProperty(PERIOD_KEY), period));
         } finally {
             QUEUE_CLEANUP_PERIOD = period;
         }

--- a/src/test/java/org/jenkinsci/plugins/queuecleanup/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/queuecleanup/ConfigAsCodeTest.java
@@ -14,7 +14,7 @@ public class ConfigAsCodeTest {
     @Test
     public void should_support_configuration_as_code() throws Exception {
         ConfigurationAsCode.get().configure(ConfigAsCodeTest.class.getResource("configuration-as-code.yml").toString());
-        Assert.assertEquals(((QueueCleanup.DescriptorImpl)r.jenkins.getDescriptor(QueueCleanup.class)).getTimeout(),123);
+        Assert.assertEquals(((QueueCleanup.DescriptorImpl)r.jenkins.getDescriptor(QueueCleanup.class)).getTimeout(),123f,0.01);
         Assert.assertEquals(((QueueCleanup.DescriptorImpl)r.jenkins.getDescriptor(QueueCleanup.class)).getItemPattern(),"^abc.*");
     }
 }


### PR DESCRIPTION
Use job full name rather than display name in pattern matching (allows matrix job configurations to be matched)